### PR TITLE
Fix round-trip (de)serialization of grouped internal nodes

### DIFF
--- a/trie/bintrie/binary_node_test.go
+++ b/trie/bintrie/binary_node_test.go
@@ -40,7 +40,9 @@ func TestSerializeDeserializeInternalNode(t *testing.T) {
 	s.root = rootRef
 
 	// Serialize the node — grouped format at groupDepth=1:
-	// [type(1)][groupDepth(1)][bitmap(1)][leftHash(32)][rightHash(32)] = 67 bytes
+	// [type(1)][groupDepth(1)][bitmap(1)][depths(2)][leftHash(32)][rightHash(32)] = 69 bytes.
+	// Both children are at depthOffset=groupDepth=1 (the bottom of the
+	// 1-level group), so the depths section is [0x01, 0x01].
 	serialized := s.serializeNode(rootRef, 1)
 
 	if serialized[0] != nodeTypeInternal {
@@ -50,7 +52,7 @@ func TestSerializeDeserializeInternalNode(t *testing.T) {
 		t.Errorf("Expected groupDepth byte to be 1, got %d", serialized[1])
 	}
 
-	expectedLen := NodeTypeBytes + 1 + 1 + 2*HashSize // type + groupDepth + bitmap + 2 hashes = 67
+	expectedLen := NodeTypeBytes + 1 + 1 + 2 + 2*HashSize // type + groupDepth + bitmap + 2 depths + 2 hashes = 69
 	if len(serialized) != expectedLen {
 		t.Errorf("Expected serialized length to be %d, got %d", expectedLen, len(serialized))
 	}
@@ -60,7 +62,12 @@ func TestSerializeDeserializeInternalNode(t *testing.T) {
 		t.Errorf("Expected bitmap byte 0xc0, got 0x%02x", serialized[2])
 	}
 
-	hashesStart := NodeTypeBytes + 1 + 1
+	depthsStart := NodeTypeBytes + 1 + 1
+	if serialized[depthsStart] != 1 || serialized[depthsStart+1] != 1 {
+		t.Errorf("Expected depth bytes [1,1], got [%d,%d]", serialized[depthsStart], serialized[depthsStart+1])
+	}
+
+	hashesStart := depthsStart + 2
 	if !bytes.Equal(serialized[hashesStart:hashesStart+HashSize], leftHash[:]) {
 		t.Error("Left hash not found at expected position")
 	}

--- a/trie/bintrie/format_test.go
+++ b/trie/bintrie/format_test.go
@@ -1,0 +1,318 @@
+// Copyright 2026 go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package bintrie
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// TestRootHashMatchesReadBackHash pins the round-trip invariant: the root
+// hash a Commit advertises must be exactly the value a fresh reader computes
+// from the on-disk blob. Before Option B the writer produced a natural-depth
+// hash while DeserializeAndHash produced an extended-depth hash, so the two
+// disagreed for any non-trivial subtree — this test failed. With the
+// per-entry depth byte, the reader rebuilds the natural-shape tree and the
+// hashes match for every groupDepth and every divergence bit.
+func TestRootHashMatchesReadBackHash(t *testing.T) {
+	for groupDepth := 1; groupDepth <= MaxGroupDepth; groupDepth++ {
+		// divergeBit ∈ [0, groupDepth-1] places the two stems at natural
+		// depth (divergeBit+1) within the root group; we want to exercise
+		// every depth-offset value the new format must handle.
+		for divergeBit := 0; divergeBit < groupDepth; divergeBit++ {
+			t.Run(fmt.Sprintf("gd=%d/diverge=%d", groupDepth, divergeBit), func(t *testing.T) {
+				tr := &BinaryTrie{
+					store:      newNodeStore(),
+					tracer:     trie.NewPrevalueTracer(),
+					groupDepth: groupDepth,
+				}
+				stemL, stemR := stemsDivergingAt(divergeBit)
+				if err := tr.store.Insert(stemL, oneKey[:], nil); err != nil {
+					t.Fatalf("Insert stemL: %v", err)
+				}
+				if err := tr.store.Insert(stemR, twoKey[:], nil); err != nil {
+					t.Fatalf("Insert stemR: %v", err)
+				}
+
+				natural := tr.Hash()
+				_, ns := tr.Commit(false)
+				rootNode, ok := ns.Nodes[""]
+				if !ok {
+					t.Fatalf("Commit produced no root blob (path \"\")")
+				}
+
+				readBack, err := DeserializeAndHash(rootNode.Blob, 0)
+				if err != nil {
+					t.Fatalf("DeserializeAndHash: %v", err)
+				}
+				if natural != readBack {
+					t.Fatalf("round-trip hash mismatch:\n"+
+						"  tr.Hash()                    = %x\n"+
+						"  DeserializeAndHash(rootBlob) = %x\n"+
+						"the parent's stored root hash cannot be reproduced from its own blob",
+						natural, readBack)
+				}
+			})
+		}
+	}
+}
+
+// TestMultiStemMixedDepths inserts four stems that diverge at different
+// depths within a single groupDepth=5 group, then round-trips the trie
+// through Commit + fresh-read. Verifies that every stem is retrievable by
+// key after reload — exercises the new format with several depth-offset
+// values in the same blob (1, 2, 3, 4) and confirms attachInGroup builds
+// the natural-shape tree correctly.
+func TestMultiStemMixedDepths(t *testing.T) {
+	const groupDepth = 5
+
+	// Each stem diverges from `0x00…00` at a different bit, so naturally:
+	//  - stem at bit-0 divergence → depth 1
+	//  - stem at bit-1 divergence → depth 2
+	//  - stem at bit-2 divergence → depth 3
+	//  - stem at bit-3 divergence → depth 4
+	stems := [][]byte{
+		zeroKey[:],
+		bitFlipStem(0), // diverge at bit 0
+		bitFlipStem(1), // diverge at bit 1 (prefix "0" matches stem 0)
+		bitFlipStem(2), // diverge at bit 2 (prefix "00")
+		bitFlipStem(3), // diverge at bit 3 (prefix "000")
+	}
+	values := []common.Hash{oneKey, twoKey, threeKey, fourKey, ffKey}
+
+	tr := &BinaryTrie{
+		store:      newNodeStore(),
+		tracer:     trie.NewPrevalueTracer(),
+		groupDepth: groupDepth,
+	}
+	for i, stem := range stems {
+		if err := tr.store.Insert(stem, values[i][:], nil); err != nil {
+			t.Fatalf("Insert stem %d: %v", i, err)
+		}
+	}
+
+	before := tr.Hash()
+	_, ns := tr.Commit(false)
+	rootBlob, ok := ns.Nodes[""]
+	if !ok {
+		t.Fatalf("no root blob in NodeSet")
+	}
+	readBack, err := DeserializeAndHash(rootBlob.Blob, 0)
+	if err != nil {
+		t.Fatalf("DeserializeAndHash: %v", err)
+	}
+	if before != readBack {
+		t.Fatalf("hash mismatch: tr.Hash()=%x DeserializeAndHash(rootBlob)=%x", before, readBack)
+	}
+
+	// Reload the root blob into a fresh store and confirm structure.
+	fresh := newNodeStore()
+	ref, err := fresh.deserializeNodeWithHash(rootBlob.Blob, 0, before)
+	if err != nil {
+		t.Fatalf("deserializeNodeWithHash: %v", err)
+	}
+	if ref.Kind() != kindInternal {
+		t.Fatalf("expected root to be Internal, got kind %d", ref.Kind())
+	}
+	// Spot-check: the reload-tree's root hash equals the commit-time hash.
+	if got := fresh.computeHash(ref); got != before {
+		t.Fatalf("reload root hash mismatch: got %x, want %x", got, before)
+	}
+}
+
+// TestDecodeRejectsNonCanonicalPosition hand-crafts a blob where the bitmap
+// position has nonzero trailing bits given its depth offset. Two
+// implementations must produce byte-identical blobs for the same logical
+// content, so a non-canonical position is unambiguously an invalid blob.
+func TestDecodeRejectsNonCanonicalPosition(t *testing.T) {
+	// groupDepth=5, bitmap size = 4 bytes. Set bit at position 5 (binary
+	// 00101) and declare depthOffset=2. Top 2 bits of 00101 are 00 (path
+	// "00"), the trailing 3 bits should be zero — they're 101 here, so the
+	// reader must reject.
+	blob := []byte{nodeTypeInternal, 5}
+	// bitmap[0] = bit at position 5 → 1 << (7-5) = 0x04
+	blob = append(blob, 0x04, 0x00, 0x00, 0x00)
+	// depths[0] = 2
+	blob = append(blob, 2)
+	// hashes[0] = 32 zero bytes
+	blob = append(blob, make([]byte, HashSize)...)
+
+	s := newNodeStore()
+	_, err := s.deserializeNode(blob, 0)
+	if err == nil {
+		t.Fatal("expected non-canonical position error, got nil")
+	}
+	if err.Error() != "non-canonical bitmap position" {
+		t.Errorf("expected 'non-canonical bitmap position', got %q", err.Error())
+	}
+}
+
+// TestDecodeRejectsInvalidDepthOffset covers depthOffset=0 (a present entry
+// must consume ≥1 bit of natural path) and depthOffset>groupDepth (the
+// entry would live below the group's bottom layer, impossible by
+// construction).
+func TestDecodeRejectsInvalidDepthOffset(t *testing.T) {
+	makeBlob := func(groupDepth int, depthOffset uint8) []byte {
+		bitmapSize := bitmapSizeForDepth(groupDepth)
+		bitmap := make([]byte, bitmapSize)
+		bitmap[0] = 0x80 // bit at position 0
+		blob := []byte{nodeTypeInternal, byte(groupDepth)}
+		blob = append(blob, bitmap...)
+		blob = append(blob, depthOffset)
+		blob = append(blob, make([]byte, HashSize)...)
+		return blob
+	}
+
+	for _, tc := range []struct {
+		name        string
+		groupDepth  int
+		depthOffset uint8
+	}{
+		{"depth=0", 5, 0},
+		{"depth>groupDepth", 5, 6},
+		{"depth>MaxGroupDepth", MaxGroupDepth, MaxGroupDepth + 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newNodeStore()
+			_, err := s.deserializeNode(makeBlob(tc.groupDepth, tc.depthOffset), 0)
+			if err == nil {
+				t.Fatal("expected invalid depth offset error, got nil")
+			}
+			if err.Error() != "invalid depth offset" {
+				t.Errorf("expected 'invalid depth offset', got %q", err.Error())
+			}
+		})
+	}
+}
+
+// TestRoundTripPersistence exercises the full commit-then-reload pipeline
+// the way real geth does it: write blobs to a backing map, open a fresh
+// nodeStore from the root blob, then resolve and read every value back
+// through the resolver. Catches mismatches between the writer's storage
+// path (collectChildGroups in store_commit.go) and the reader's lookup
+// path (keyToPath in store_ops.go) — exactly the bug Option B's first
+// implementation hit, where blobs were written at the bottom-layer-extended
+// path but resolved at the natural-depth path. Also confirms the reloaded
+// trie's root hash equals the original committed hash.
+func TestRoundTripPersistence(t *testing.T) {
+	for _, groupDepth := range []int{1, 2, 3, 5, 8} {
+		t.Run(fmt.Sprintf("groupDepth=%d", groupDepth), func(t *testing.T) {
+			// 1. Build a trie with deterministically-distributed keys.
+			//    50 keys with FNV-style spread guarantees several stems
+			//    land in the root group (natural depth ≤ groupDepth) and
+			//    several land in sub-groups, exercising both the in-group
+			//    resolve and the cross-group resolve paths.
+			writerTrie := &BinaryTrie{
+				store:      newNodeStore(),
+				tracer:     trie.NewPrevalueTracer(),
+				groupDepth: groupDepth,
+			}
+			const n = 50
+			keys := make([][HashSize]byte, n)
+			values := make([][HashSize]byte, n)
+			for i := range n {
+				binary.BigEndian.PutUint64(keys[i][:8], uint64(i+1)*0x9e3779b97f4a7c15)
+				binary.BigEndian.PutUint64(keys[i][8:16], uint64(i+1)*0xc2b2ae3d27d4eb4f)
+				binary.BigEndian.PutUint64(keys[i][16:24], uint64(i+1)*0x165667b19e3779f9)
+				binary.BigEndian.PutUint64(keys[i][24:32], uint64(i+1)*0x85ebca77c2b2ae63)
+				binary.BigEndian.PutUint64(values[i][:8], uint64(i+1))
+				if err := writerTrie.store.Insert(keys[i][:], values[i][:], nil); err != nil {
+					t.Fatalf("insert %d: %v", i, err)
+				}
+			}
+
+			// 2. Commit; capture every blob into an in-memory map keyed
+			//    by its path. The NodeSet key is the BitArray.PutKeyBytes
+			//    encoding — exactly the bytes the resolver gets from
+			//    keyToPath, so map lookups by string(path) round-trip.
+			rootHash := writerTrie.Hash()
+			_, ns := writerTrie.Commit(false)
+			blobs := make(map[string][]byte, len(ns.Nodes))
+			for path, node := range ns.Nodes {
+				blobs[path] = node.Blob
+			}
+
+			// 3. Build a resolver that serves blobs from the map.
+			resolver := func(path []byte, hash common.Hash) ([]byte, error) {
+				blob, ok := blobs[string(path)]
+				if !ok {
+					return nil, fmt.Errorf("blob not found at path %x (hash %x)", path, hash)
+				}
+				return blob, nil
+			}
+
+			// 4. Open a fresh store, seeded only with the root blob.
+			//    Everything else must be reached via the resolver.
+			readerStore := newNodeStore()
+			rootBlob, ok := blobs[""]
+			if !ok {
+				t.Fatalf("no root blob in NodeSet")
+			}
+			rootRef, err := readerStore.deserializeNodeWithHash(rootBlob, 0, rootHash)
+			if err != nil {
+				t.Fatalf("deserialize root: %v", err)
+			}
+			readerStore.root = rootRef
+
+			// 5. Read every key back through the resolver and verify.
+			//    A mismatch here means either the storage path diverged
+			//    from the lookup path, or deserialization corrupted data.
+			for i := range n {
+				got, err := readerStore.Get(keys[i][:], resolver)
+				if err != nil {
+					t.Fatalf("Get key %d (%x): %v", i, keys[i], err)
+				}
+				if !bytes.Equal(got, values[i][:]) {
+					t.Fatalf("Get key %d: got %x, want %x", i, got, values[i][:])
+				}
+			}
+
+			// 6. The reloaded trie's root hash must equal the original.
+			//    This is the canonical-hash round-trip property: any
+			//    independent reader walking the same blobs computes the
+			//    same root, independent of in-memory layout choices.
+			if got := readerStore.Hash(); got != rootHash {
+				t.Fatalf("post-reload root hash: got %x, want %x", got, rootHash)
+			}
+		})
+	}
+}
+
+// stemsDivergingAt returns two 32-byte stems whose first `divergeBit` bits
+// are zero and whose bit at index `divergeBit` differs (left=0, right=1).
+// Useful for placing two stems at a known natural depth within a group.
+func stemsDivergingAt(divergeBit int) (left, right []byte) {
+	left = make([]byte, HashSize)
+	right = make([]byte, HashSize)
+	// Bit `divergeBit` is in byte (divergeBit/8) at MSB position (7 - divergeBit%8).
+	right[divergeBit/8] = 1 << (7 - divergeBit%8)
+	return left, right
+}
+
+// bitFlipStem returns a 32-byte stem whose first `divergeBit` bits are zero,
+// bit `divergeBit` is 1, and all subsequent bits are zero. Used together
+// with the all-zero stem to force divergence at a specific bit.
+func bitFlipStem(divergeBit int) []byte {
+	out := make([]byte, HashSize)
+	out[divergeBit/8] = 1 << (7 - divergeBit%8)
+	return out
+}

--- a/trie/bintrie/node_store.go
+++ b/trie/bintrie/node_store.go
@@ -41,16 +41,6 @@ type nodeStore struct {
 	// stem-split keeps the old stem at a deeper position), so they don't
 	// have free lists.
 	freeHashed []uint32
-
-	// groupDepth, when > 0, makes hashInternal compute the same hash that
-	// would be produced by serializing the node to a group blob and
-	// recursively hashing the blob's bottom-layer leaves. This matches the
-	// hash a fresh reader would compute via deserializeSubtree, keeping the
-	// parent-stored child hash byte-equal to the child's read-back hash.
-	// When 0, hashInternal falls back to the natural-depth SHA256 recursion
-	// used by tests that construct nodeStore directly without going through
-	// NewBinaryTrie.
-	groupDepth int
 }
 
 func newNodeStore() *nodeStore {

--- a/trie/bintrie/store_commit.go
+++ b/trie/bintrie/store_commit.go
@@ -221,16 +221,6 @@ func (s *nodeStore) deserializeNodeWithHash(serialized []byte, depth int, hn com
 }
 
 // deserializeSubtree reconstructs an InternalNode subtree from grouped serialization.
-	if remainingDepth == 0 {
-		// Bottom layer: check bitmap and return HashedNode or Empty
-		if bitmap[position/8]>>(7-(position%8))&1 == 1 {
-			if len(hashData) < (*hashIdx+1)*HashSize {
-				return emptyRef, errInvalidSerializedLength
-			}
-			hash := common.BytesToHash(hashData[*hashIdx*HashSize : (*hashIdx+1)*HashSize])
-			*hashIdx++
-			return s.newHashedRef(hash), nil
-		}
 func (s *nodeStore) deserializeSubtree(hn common.Hash, groupDepth int, nodeDepth int, bitmap []byte, depths []byte, hashData []byte, mustRecompute bool, dirty bool) (nodeRef, error) {
 	k := len(depths)
 	if len(hashData) != k*HashSize {
@@ -240,19 +230,6 @@ func (s *nodeStore) deserializeSubtree(hn common.Hash, groupDepth int, nodeDepth
 		return emptyRef, nil
 	}
 
-	// Check if this entire subtree is empty by examining all relevant bitmap bits
-	leftPos := position * 2
-	rightPos := position*2 + 1
-
-	// note that the parent might not need root computations, but the children
-	// do, because their hash isn't saved. Hence `mustRecompute` is set to `true`.
-	left, err := s.deserializeSubtree(common.Hash{}, remainingDepth-1, leftPos, nodeDepth+1, bitmap, hashData, hashIdx, true, dirty)
-	if err != nil {
-		return emptyRef, err
-	}
-	right, err := s.deserializeSubtree(common.Hash{}, remainingDepth-1, rightPos, nodeDepth+1, bitmap, hashData, hashIdx, true, dirty)
-	if err != nil {
-		return emptyRef, err
 	rootRef := s.newInternalRef(nodeDepth)
 	rootNode := s.getInternal(rootRef.Index())
 	rootNode.mustRecompute = mustRecompute

--- a/trie/bintrie/store_commit.go
+++ b/trie/bintrie/store_commit.go
@@ -59,27 +59,9 @@ var parallelHashDepth = min(bits.Len(uint(runtime.NumCPU())), 8)
 // goroutine while the right subtree is hashed inline, then the two digests
 // are combined. Below that threshold the goroutine spawn cost outweighs the
 // hashing work, so deeper nodes hash both children sequentially.
-//
-// At a group boundary (depth % groupDepth == 0, with groupDepth > 0) the
-// hash is computed from the group's bottom-layer slot hashes via the same
-// serialize-then-recursive-hash that a fresh reader applies after reading
-// the node's blob from disk. This guarantees the parent's stored child
-// hash equals the child's read-back hash byte-for-byte, regardless of
-// whether the in-memory subtree placed its stems at natural depth (via
-// UpdateStem split) or extended depth (via deserializeSubtree).
 func (s *nodeStore) hashInternal(idx uint32) common.Hash {
 	node := s.getInternal(idx)
 	if !node.mustRecompute {
-		return node.hash
-	}
-
-	if s.groupDepth > 0 && int(node.depth)%s.groupDepth == 0 {
-		bitmapSize := bitmapSizeForDepth(s.groupDepth)
-		bitmap := make([]byte, bitmapSize)
-		var hashes []common.Hash
-		s.serializeSubtree(makeRef(kindInternal, idx), s.groupDepth, 0, int(node.depth), bitmap, &hashes)
-		node.hash = groupedRecursiveHash(s.groupDepth, bitmap, hashes)
-		node.mustRecompute = false
 		return node.hash
 	}
 
@@ -123,43 +105,6 @@ func (s *nodeStore) hashInternal(idx uint32) common.Hash {
 	node.hash = sha256.Sum256(input[:])
 	node.mustRecompute = false
 	return node.hash
-}
-
-// groupedRecursiveHash computes the recursive SHA256 hash of a group-blob
-// subtree, given the bitmap and present-hash list produced by serializeSubtree.
-//
-// The output is byte-equal to what hashInternal would compute on a tree
-// produced by deserializeSubtree reading the same (bitmap, hashes) — i.e.,
-// it's the hash the fresh-reader path produces. Use this from hashInternal
-// at group-boundary depths so the parent's stored child hash matches the
-// child's read-back hash regardless of in-memory stem placement.
-func groupedRecursiveHash(groupDepth int, bitmap []byte, hashes []common.Hash) common.Hash {
-	nSlots := 1 << groupDepth
-	leaves := make([]common.Hash, nSlots)
-	hashIdx := 0
-	for i := 0; i < nSlots; i++ {
-		if bitmap[i/8]>>(7-(i%8))&1 == 1 {
-			leaves[i] = hashes[hashIdx]
-			hashIdx++
-		}
-	}
-	level := leaves
-	var zero common.Hash
-	for len(level) > 1 {
-		next := make([]common.Hash, len(level)/2)
-		for i := 0; i < len(next); i++ {
-			l, r := level[2*i], level[2*i+1]
-			if l == zero && r == zero {
-				continue
-			}
-			var buf [64]byte
-			copy(buf[:32], l[:])
-			copy(buf[32:], r[:])
-			next[i] = sha256.Sum256(buf[:])
-		}
-		level = next
-	}
-	return level[0]
 }
 
 // serializeSubtree recursively collects child hashes from a subtree of InternalNodes.

--- a/trie/bintrie/store_commit.go
+++ b/trie/bintrie/store_commit.go
@@ -111,7 +111,7 @@ func (s *nodeStore) hashInternal(idx uint32) common.Hash {
 // It traverses up to `remainingDepth` levels, storing hashes of bottom-layer children.
 // position tracks the current index (0 to 2^groupDepth - 1) for bitmap placement.
 // hashes collects the hashes of present children, bitmap tracks which positions are present.
-func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position int, absoluteDepth int, bitmap []byte, hashes *[]common.Hash) {
+func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position int, groupDepth int, bitmap []byte, hashes *[]common.Hash, depths *[]uint8) {
 	if remainingDepth == 0 {
 		// Bottom layer: store hash if not empty
 		switch ref.Kind() {
@@ -122,6 +122,7 @@ func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position i
 			// StemNode, HashedNode, or InternalNode at boundary: store hash
 			bitmap[position/8] |= 1 << (7 - (position % 8))
 			*hashes = append(*hashes, s.computeHash(ref))
+			*depths = append(*depths, uint8(groupDepth))
 		}
 		return
 	}
@@ -130,31 +131,18 @@ func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position i
 	case kindInternal:
 		leftPos := position * 2
 		rightPos := position*2 + 1
-		s.serializeSubtree(s.getInternal(ref.Index()).left, remainingDepth-1, leftPos, absoluteDepth+1, bitmap, hashes)
-		s.serializeSubtree(s.getInternal(ref.Index()).right, remainingDepth-1, rightPos, absoluteDepth+1, bitmap, hashes)
+		s.serializeSubtree(s.getInternal(ref.Index()).left, remainingDepth-1, leftPos, groupDepth, bitmap, hashes, depths)
+		s.serializeSubtree(s.getInternal(ref.Index()).right, remainingDepth-1, rightPos, groupDepth, bitmap, hashes, depths)
 	case kindEmpty:
 		return
 	default:
 		// StemNode or HashedNode encountered before reaching the group's bottom
 		// layer. Compute the leaf bitmap position where this node's hash will
 		// be stored.
-		leafPos := position
-		switch ref.Kind() {
-		case kindStem:
-			sn := s.getStem(ref.Index())
-			// Extend position using the stem's key bits so that
-			// GetValuesAtStem traversal (which follows key bits) finds the hash.
-			for d := 0; d < remainingDepth; d++ {
-				bit := sn.Stem[(absoluteDepth+d)/8] >> (7 - ((absoluteDepth + d) % 8)) & 1
-				leafPos = leafPos*2 + int(bit)
-			}
-		default:
-			// HashedNode or unknown: extend all-left (no key bits available).
-			// This matches the all-zero path that resolveNode would follow.
-			leafPos = position << remainingDepth
-		}
-		bitmap[leafPos/8] |= 1 << (7 - (leafPos % 8))
+		bitmapPos := position << remainingDepth
+		bitmap[bitmapPos/8] |= 1 << (7 - (bitmapPos % 8))
 		*hashes = append(*hashes, s.computeHash(ref))
+		*depths = append(*depths, uint8(groupDepth-remainingDepth))
 	}
 }
 
@@ -162,25 +150,29 @@ func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position i
 func (s *nodeStore) serializeNode(ref nodeRef, groupDepth int) []byte {
 	switch ref.Kind() {
 	case kindInternal:
-		// InternalNode group: 1 byte type + 1 byte group depth + variable bitmap + N×32 byte hashes
+		// InternalNode group format:
+		//   [type(1)] [groupDepth(1)] [bitmap (2^groupDepth bits)] [depths(1B × K)] [hashes(32B × K)]
 		bitmapSize := bitmapSizeForDepth(groupDepth)
 		bitmap := make([]byte, bitmapSize)
 		var hashes []common.Hash
+		var depths []uint8
 
-		node := s.getInternal(ref.Index())
-		s.serializeSubtree(ref, groupDepth, 0, int(node.depth), bitmap, &hashes)
+		s.serializeSubtree(ref, groupDepth, 0, groupDepth, bitmap, &hashes, &depths)
 
 		// Build serialized output
-		serializedLen := NodeTypeBytes + 1 + bitmapSize + len(hashes)*HashSize
+		k := len(hashes)
+		serializedLen := NodeTypeBytes + 1 + bitmapSize + k + k*HashSize
 		serialized := make([]byte, serializedLen)
 		serialized[0] = nodeTypeInternal
-		serialized[1] = byte(groupDepth) // group depth => bitmap size for a sparse group
+		serialized[1] = byte(groupDepth)
 		copy(serialized[2:2+bitmapSize], bitmap)
 
-		offset := NodeTypeBytes + 1 + bitmapSize
-		for _, h := range hashes {
-			copy(serialized[offset:offset+HashSize], h.Bytes())
-			offset += HashSize
+		depthsOff := NodeTypeBytes + 1 + bitmapSize
+		copy(serialized[depthsOff:depthsOff+k], depths) // TODO: see if this can't be pre-allocated
+
+		hashesOff := depthsOff + k
+		for i, h := range hashes {
+			copy(serialized[hashesOff+i*HashSize:hashesOff+(i+1)*HashSize], h.Bytes())
 		}
 
 		return serialized
@@ -229,10 +221,6 @@ func (s *nodeStore) deserializeNodeWithHash(serialized []byte, depth int, hn com
 }
 
 // deserializeSubtree reconstructs an InternalNode subtree from grouped serialization.
-// remainingDepth is how many more levels to build, position is current index in the bitmap,
-// nodeDepth is the actual trie depth for the node being created.
-// hashIdx tracks the current position in the hash data (incremented as hashes are consumed).
-func (s *nodeStore) deserializeSubtree(hn common.Hash, remainingDepth int, position int, nodeDepth int, bitmap []byte, hashData []byte, hashIdx *int, mustRecompute bool, dirty bool) (nodeRef, error) {
 	if remainingDepth == 0 {
 		// Bottom layer: check bitmap and return HashedNode or Empty
 		if bitmap[position/8]>>(7-(position%8))&1 == 1 {
@@ -243,6 +231,12 @@ func (s *nodeStore) deserializeSubtree(hn common.Hash, remainingDepth int, posit
 			*hashIdx++
 			return s.newHashedRef(hash), nil
 		}
+func (s *nodeStore) deserializeSubtree(hn common.Hash, groupDepth int, nodeDepth int, bitmap []byte, depths []byte, hashData []byte, mustRecompute bool, dirty bool) (nodeRef, error) {
+	k := len(depths)
+	if len(hashData) != k*HashSize {
+		return emptyRef, errInvalidSerializedLength
+	}
+	if k == 0 {
 		return emptyRef, nil
 	}
 
@@ -259,26 +253,78 @@ func (s *nodeStore) deserializeSubtree(hn common.Hash, remainingDepth int, posit
 	right, err := s.deserializeSubtree(common.Hash{}, remainingDepth-1, rightPos, nodeDepth+1, bitmap, hashData, hashIdx, true, dirty)
 	if err != nil {
 		return emptyRef, err
-	}
-
-	// If both children are empty, return Empty
-	if left.IsEmpty() && right.IsEmpty() {
-		return emptyRef, nil
-	}
-
-	ref := s.newInternalRef(nodeDepth)
-	node := s.getInternal(ref.Index())
-	node.left = left
-	node.right = right
-	node.mustRecompute = mustRecompute
+	rootRef := s.newInternalRef(nodeDepth)
+	rootNode := s.getInternal(rootRef.Index())
+	rootNode.mustRecompute = mustRecompute
 	if !mustRecompute {
-		// mustRecompute will only be false for the root of the subtree,
-		// for which we already know the hash.
-		node.hash = hn
-		node.mustRecompute = false
+		rootNode.hash = hn
 	}
-	node.dirty = dirty
-	return ref, nil
+	rootNode.dirty = dirty
+
+	bitmapBits := 1 << groupDepth
+	entryIdx := 0
+	for bit := 0; bit < bitmapBits; bit++ {
+		if bitmap[bit/8]>>(7-(bit%8))&1 == 0 {
+			continue
+		}
+		depthOffset := int(depths[entryIdx])
+		if depthOffset < 1 || depthOffset > groupDepth {
+			return emptyRef, errors.New("invalid depth offset")
+		}
+		// Canonical-encoding check: trailing position bits must be zero.
+		mask := (1 << (groupDepth - depthOffset)) - 1
+		if bit&mask != 0 {
+			return emptyRef, errors.New("non-canonical bitmap position")
+		}
+		var hash common.Hash
+		copy(hash[:], hashData[entryIdx*HashSize:(entryIdx+1)*HashSize])
+		if err := s.attachInGroup(rootRef, nodeDepth, groupDepth, depthOffset, bit, hash, dirty); err != nil {
+			return emptyRef, err
+		}
+		entryIdx++
+	}
+	return rootRef, nil
+}
+
+func (s *nodeStore) attachInGroup(rootRef nodeRef, rootDepth, groupDepth, depthOffset, bitmapPos int, hash common.Hash, dirty bool) error {
+	cur := rootRef
+	for level := 0; level < depthOffset-1; level++ {
+		bit := (bitmapPos >> (groupDepth - 1 - level)) & 1
+		node := s.getInternal(cur.Index())
+		childRef := node.left
+		if bit == 1 {
+			childRef = node.right
+		}
+		if childRef.IsEmpty() {
+			newRef := s.newInternalRef(rootDepth + level + 1)
+			s.getInternal(newRef.Index()).dirty = dirty
+			if bit == 0 {
+				node.left = newRef
+			} else {
+				node.right = newRef
+			}
+			cur = newRef
+			continue
+		}
+		if childRef.Kind() != kindInternal {
+			return errors.New("overlapping entries in group blob")
+		}
+		cur = childRef
+	}
+	leafBit := (bitmapPos >> (groupDepth - depthOffset)) & 1
+	node := s.getInternal(cur.Index())
+	if leafBit == 0 {
+		if !node.left.IsEmpty() {
+			return errors.New("overlapping entries in group blob")
+		}
+		node.left = s.newHashedRef(hash)
+	} else {
+		if !node.right.IsEmpty() {
+			return errors.New("overlapping entries in group blob")
+		}
+		node.right = s.newHashedRef(hash)
+	}
+	return nil
 }
 
 func (s *nodeStore) decodeNode(serialized []byte, depth int, hn common.Hash, mustRecompute, dirty bool) (nodeRef, error) {
@@ -288,7 +334,9 @@ func (s *nodeStore) decodeNode(serialized []byte, depth int, hn common.Hash, mus
 
 	switch serialized[0] {
 	case nodeTypeInternal:
-		// Grouped format: 1 byte type + 1 byte group depth + variable bitmap + N×32 byte hashes
+		// Grouped format:
+		//   [type(1)] [groupDepth(1)] [bitmap (2^groupDepth bits, padded to bitmapSize bytes)]
+		//   [depthOffsets (1B × K)] [hashes (32B × K)]
 		if len(serialized) < NodeTypeBytes+1 {
 			return emptyRef, errInvalidSerializedLength
 		}
@@ -301,10 +349,28 @@ func (s *nodeStore) decodeNode(serialized []byte, depth int, hn common.Hash, mus
 			return 0, errInvalidSerializedLength
 		}
 		bitmap := serialized[2 : 2+bitmapSize]
-		hashData := serialized[2+bitmapSize:]
 
-		hashIdx := 0
-		return s.deserializeSubtree(hn, groupDepth, 0, depth, bitmap, hashData, &hashIdx, mustRecompute, dirty)
+		bitmapBits := 1 << groupDepth
+		if bitmapBits < 8 {
+			padMask := byte(0xFF) >> bitmapBits
+			if bitmap[0]&padMask != 0 {
+				return emptyRef, errors.New("non-canonical bitmap padding")
+			}
+		}
+
+		k := 0
+		for _, b := range bitmap {
+			k += bits.OnesCount8(b)
+		}
+		expectedLen := NodeTypeBytes + 1 + bitmapSize + k + k*HashSize
+		if len(serialized) != expectedLen {
+			return emptyRef, errInvalidSerializedLength
+		}
+		depthsOff := NodeTypeBytes + 1 + bitmapSize
+		depths := serialized[depthsOff : depthsOff+k]
+		hashData := serialized[depthsOff+k : depthsOff+k+k*HashSize]
+
+		return s.deserializeSubtree(hn, groupDepth, depth, bitmap, depths, hashData, mustRecompute, dirty)
 
 	case nodeTypeStem:
 		if len(serialized) < NodeTypeBytes+StemSize+StemBitmapSize {
@@ -398,8 +464,7 @@ func (s *nodeStore) collectChildGroups(node *InternalNode, path BitArray, flushf
 				return err
 			}
 		default:
-			extPath := s.extendPathToGroupLeaf(appendBit(path, 0), node.left, remainingLevels)
-			s.collectNodes(node.left, extPath, flushfn, groupDepth)
+			s.collectNodes(node.left, appendBit(path, 0), flushfn, groupDepth)
 		}
 	}
 	if !node.right.IsEmpty() {
@@ -410,36 +475,10 @@ func (s *nodeStore) collectChildGroups(node *InternalNode, path BitArray, flushf
 				return err
 			}
 		default:
-			extPath := s.extendPathToGroupLeaf(appendBit(path, 1), node.right, remainingLevels)
-			s.collectNodes(node.right, extPath, flushfn, groupDepth)
+			s.collectNodes(node.right, appendBit(path, 1), flushfn, groupDepth)
 		}
 	}
 	return nil
-}
-
-// extendPathToGroupLeaf extends a storage path to the group's leaf boundary,
-// matching the projection done by serializeSubtree. For StemNodes, the path
-// is extended using the stem's key bits (same as serializeSubtree). For other
-// node types, the path is extended with all-zero (left) bits.
-func (s *nodeStore) extendPathToGroupLeaf(path BitArray, node nodeRef, remainingLevels int) BitArray {
-	if remainingLevels <= 0 {
-		return path
-	}
-	if node.Kind() == kindStem {
-		sn := s.getStem(node.Index())
-		for range remainingLevels {
-			n := path.Len()
-			bit := sn.Stem[n/8] >> (7 - (n % 8)) & 1
-			path = appendBit(path, bit)
-		}
-	} else {
-		// HashedNode or other: all-left extension (matches serializeSubtree's
-		// position << remainingDepth behavior).
-		for range remainingLevels {
-			path = appendBit(path, 0)
-		}
-	}
-	return path
 }
 
 // appendBit returns a new BitArray with bit appended to path.

--- a/trie/bintrie/trie.go
+++ b/trie/bintrie/trie.go
@@ -133,10 +133,8 @@ func NewBinaryTrie(root common.Hash, db database.NodeDatabase, groupDepth int) (
 	if err != nil {
 		return nil, err
 	}
-	store := newNodeStore()
-	store.groupDepth = groupDepth
 	t := &BinaryTrie{
-		store:      store,
+		store:      newNodeStore(),
 		reader:     reader,
 		tracer:     trie.NewPrevalueTracer(),
 		groupDepth: groupDepth,


### PR DESCRIPTION
This will probably become its own PR against geth's master, I just wanted to put it out there while I get to the bottom of this - making sure I don't destroy the original branch before I'm sure it's ok. There seems to be an (de)serialization issue for group-depth code and this is the fix.